### PR TITLE
#1 Added permission recreation via Apache Tools (dirty way)

### DIFF
--- a/src/io/github/lukehutch/quickunzip/Utils.java
+++ b/src/io/github/lukehutch/quickunzip/Utils.java
@@ -110,7 +110,7 @@ class Utils {
         /** Completion barrier. */
         @Override
         public void close() {
-            for (final var future : this) {
+            for (final Future future : this) {
                 try {
                     future.get();
                 } catch (final Exception e) {


### PR DESCRIPTION
The "var"s had been replaced by IntelliJ.

The solution is using Apache Commons Compress lib, but only to extract the permissions...the rest is still old, but maybe worth to be converted to use Apache everywhere (didn't tested)

Works now on MacOSX